### PR TITLE
fix: fix empty label live-transcription appearing in the list of live-transcriptions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "~0.0.73",
+  "requiredSdkVersion": "~0.0.94",
   "name": "LiveTranscriptionPlugin",
   "javascriptEntrypointUrl": "LiveTranscriptionPlugin.js",
   "localesBaseUrl": "locales"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "dependencies": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.92",
+        "bigbluebutton-html-plugin-sdk": "0.0.94",
         "path": "^0.12.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3345,9 +3345,9 @@
       "dev": true
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.92",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.92.tgz",
-      "integrity": "sha512-Muw4Yfr3c3tVgWAX4AIEQ3BUmG6tQ8PzLkYvD+5UJ53o87omrQ8Ynm7YPZ8Ioqx72+NhQ/9/oWgYrJxn8tXabw==",
+      "version": "0.0.94",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.94.tgz",
+      "integrity": "sha512-sBTrpD03CdQ11CH6L1OA7gDe6vBqJ1RxHkNY68pNwhlB7pdrVwdhW++YzGLCTyBcih+TCetupAZ/dixM1a7IdQ==",
       "dependencies": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./src/index.tsx",
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.92",
+    "bigbluebutton-html-plugin-sdk": "0.0.94",
     "path": "^0.12.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/app/component.tsx
+++ b/src/components/app/component.tsx
@@ -62,7 +62,9 @@ export function LiveTranscriptionPlugin(
 
   useEffect(() => {
     if (captionActiveLocalesResult && intl && permissionToLoad) {
-      const sidekickPanelsList = captionActiveLocalesResult.caption_activeLocales.map(
+      const sidekickPanelsList = captionActiveLocalesResult.caption_activeLocales
+      .filter((activeCaptionLocale) => activeCaptionLocale.locale !== '')
+      .map(
         (activeCaptionLocale) => new GenericContentSidekickArea({
           name: intl.formatMessage(intlMessages.sidekickMenuTitle, {
             0: activeCaptionLocale.locale,

--- a/src/components/app/component.tsx
+++ b/src/components/app/component.tsx
@@ -66,6 +66,7 @@ export function LiveTranscriptionPlugin(
       .filter((activeCaptionLocale) => activeCaptionLocale.locale !== '')
       .map(
         (activeCaptionLocale) => new GenericContentSidekickArea({
+          id: `live-transcription-${activeCaptionLocale.locale}-${uuid}`,
           name: intl.formatMessage(intlMessages.sidekickMenuTitle, {
             0: activeCaptionLocale.locale,
           }),


### PR DESCRIPTION
### What does this PR do?

Removes empty labeled live transcription option when disabling it. 

It also updates SDK to support custom-query feature.

### Closes Issue(s)

Closes #6

### More
See demo video ahead:

https://github.com/user-attachments/assets/cb065442-212b-41fd-97bd-c2ca0083e839




