### PR TITLE
fix: wrong interactions with typed-captions

### DIFF
--- a/src/components/app/component.tsx
+++ b/src/components/app/component.tsx
@@ -65,31 +65,31 @@ export function LiveTranscriptionPlugin(
       const uniqueActiveLocales = new Set(
         captionActiveLocalesResult.caption_activeLocales
           .map((activeCaptionLocale) => activeCaptionLocale.locale)
-          .filter((locale) => locale !== '')
+          .filter((locale) => locale !== ''),
       );
       const sidekickPanelsList = Array.from(uniqueActiveLocales)
-      .map(
-        (activeCaptionLocale) => new GenericContentSidekickArea({
-          id: `live-transcription-${activeCaptionLocale}-${uuid}`,
-          name: intl.formatMessage(intlMessages.sidekickMenuTitle, {
-            0: activeCaptionLocale,
+        .map(
+          (activeCaptionLocale) => new GenericContentSidekickArea({
+            id: `live-transcription-${activeCaptionLocale}-${uuid}`,
+            name: intl.formatMessage(intlMessages.sidekickMenuTitle, {
+              0: activeCaptionLocale,
+            }),
+            buttonIcon: 'closed_caption',
+            section: intl.formatMessage(intlMessages.sidekickSectionName),
+            open: false,
+            contentFunction: (element: HTMLElement) => {
+              const root = ReactDOM.createRoot(element);
+              root.render(
+                (<LiveTranscriptionSidekickContent
+                  captionLocale={activeCaptionLocale}
+                  pluginApi={pluginApi}
+                  intl={intl}
+                />),
+              );
+              return root;
+            },
           }),
-          buttonIcon: 'closed_caption',
-          section: intl.formatMessage(intlMessages.sidekickSectionName),
-          open: false,
-          contentFunction: (element: HTMLElement) => {
-            const root = ReactDOM.createRoot(element);
-            root.render(
-              (<LiveTranscriptionSidekickContent
-                captionLocale={activeCaptionLocale}
-                pluginApi={pluginApi}
-                intl={intl}
-              />),
-            );
-            return root;
-          },
-        }),
-      );
+        );
       pluginApi.setGenericContentItems([...sidekickPanelsList]);
     }
   }, [captionActiveLocalesResult, intl, permissionToLoad]);

--- a/src/components/app/component.tsx
+++ b/src/components/app/component.tsx
@@ -62,13 +62,17 @@ export function LiveTranscriptionPlugin(
 
   useEffect(() => {
     if (captionActiveLocalesResult && intl && permissionToLoad) {
-      const sidekickPanelsList = captionActiveLocalesResult.caption_activeLocales
-      .filter((activeCaptionLocale) => activeCaptionLocale.locale !== '')
+      const uniqueActiveLocales = new Set(
+        captionActiveLocalesResult.caption_activeLocales
+          .map((activeCaptionLocale) => activeCaptionLocale.locale)
+          .filter((locale) => locale !== '')
+      );
+      const sidekickPanelsList = Array.from(uniqueActiveLocales)
       .map(
         (activeCaptionLocale) => new GenericContentSidekickArea({
-          id: `live-transcription-${activeCaptionLocale.locale}-${uuid}`,
+          id: `live-transcription-${activeCaptionLocale}-${uuid}`,
           name: intl.formatMessage(intlMessages.sidekickMenuTitle, {
-            0: activeCaptionLocale.locale,
+            0: activeCaptionLocale,
           }),
           buttonIcon: 'closed_caption',
           section: intl.formatMessage(intlMessages.sidekickSectionName),
@@ -77,7 +81,7 @@ export function LiveTranscriptionPlugin(
             const root = ReactDOM.createRoot(element);
             root.render(
               (<LiveTranscriptionSidekickContent
-                captionLocale={activeCaptionLocale.locale}
+                captionLocale={activeCaptionLocale}
                 pluginApi={pluginApi}
                 intl={intl}
               />),


### PR DESCRIPTION
### What does this PR do?

It fixes some weird interactions with typed-captions (when that plugin creates a new active caption locale, it can duplicate that key for the live-transcription plugin).

### Closes Issue(s)

Closes #10

### More


See quick demo ahead:

https://github.com/user-attachments/assets/0b5e7eab-41d9-4244-b543-f03b24781a3b


